### PR TITLE
Make key and secret optional

### DIFF
--- a/src/Queue/Connectors/SqsFifoConnector.php
+++ b/src/Queue/Connectors/SqsFifoConnector.php
@@ -24,7 +24,7 @@ class SqsFifoConnector extends SqsConnector
             throw new InvalidArgumentException('FIFO queue name must end in ".fifo"');
         }
 
-        if ($config['key'] && $config['secret']) {
+        if (array_key_exists('key', $config) && array_key_exists('secret', $config)) {
             $config['credentials'] = array_only($config, ['key', 'secret']);
         }
 


### PR DESCRIPTION
For use with IAM EC2/ECS/Task Roles

It looks like you had done this - however if statements don't work if the key is not set, a better method is to use `array_key_exists`