### PR TITLE
Notification group and deduplicater support added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,34 @@ dispatch(
 );
 ```
 
+Notification
+
+``` php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use ShiftOneLabs\LaravelSqsFifoQueue\Bus\SqsFifoQueueable;
+
+class ExampleNotification extends Notification implements ShouldQueue
+{
+    use Queueable, SqsFifoQueueable;
+
+```
+
+Usage:
+
+``` php
+$user->notify(
+    (new ExampleNotification($notification))
+        ->locale($user->language)
+        ->onMessageGroup('important')
+);
+```
+
 #### Custom Deduplicator
 
 The deduplicators work by generating a deduplication id that is sent to the queue. If two messages generate the same deduplication id, the second message is considered a duplicate, and the message will not be delivered if it is within the 5 minute deduplication interval.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/queue": ">=4.1",
-        "illuminate/notifications": ">=5.3",
         "aws/aws-sdk-php": "~3.0",
         "ramsey/uuid": "~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/queue": ">=4.1",
+        "illuminate/notifications": ">=5.3",
         "aws/aws-sdk-php": "~3.0",
         "ramsey/uuid": "~3.0"
     },

--- a/src/SqsFifoQueue.php
+++ b/src/SqsFifoQueue.php
@@ -6,6 +6,7 @@ use LogicException;
 use Aws\Sqs\SqsClient;
 use BadMethodCallException;
 use InvalidArgumentException;
+use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Queue\SqsQueue;
 use ShiftOneLabs\LaravelSqsFifoQueue\Contracts\Queue\Deduplicator;
 
@@ -224,10 +225,18 @@ class SqsFifoQueue extends SqsQueue
             return [];
         }
 
+        if ($job instanceof SendQueuedNotifications) {
+            $messageGroupId = isset($job->notification->messageGroupId) ? $job->notification->messageGroupId : null;
+            $deduplicator = isset($job->notification->deduplicator) ? $job->notification->deduplicator : null;
+        } else {
+            $messageGroupId = isset($job->messageGroupId) ? $job->messageGroupId : null;
+            $deduplicator = isset($job->deduplicator) ? $job->deduplicator : null;
+        }
+
         return array_filter(
             [
-                'group' => isset($job->messageGroupId) ? $job->messageGroupId : null,
-                'deduplicator' => isset($job->deduplicator) ? $job->deduplicator : null,
+                'group' => $messageGroupId,
+                'deduplicator' => $deduplicator,
             ],
             function ($value) {
                 return $value !== null;

--- a/src/SqsFifoQueue.php
+++ b/src/SqsFifoQueue.php
@@ -6,7 +6,6 @@ use LogicException;
 use Aws\Sqs\SqsClient;
 use BadMethodCallException;
 use InvalidArgumentException;
-use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Queue\SqsQueue;
 use ShiftOneLabs\LaravelSqsFifoQueue\Contracts\Queue\Deduplicator;
 
@@ -225,7 +224,7 @@ class SqsFifoQueue extends SqsQueue
             return [];
         }
 
-        if ($job instanceof SendQueuedNotifications) {
+        if (get_class($job) == 'Illuminate\Notifications\SendQueuedNotifications') {
             $messageGroupId = isset($job->notification->messageGroupId) ? $job->notification->messageGroupId : null;
             $deduplicator = isset($job->notification->deduplicator) ? $job->notification->deduplicator : null;
         } else {


### PR DESCRIPTION
I added support for group and deduplicater to queued notifications.
To use instanceof Illuminate\Notifications\SendQueuedNotifications i added an composer requirement.
If preffered we can just replace it with get_class to support Laravel lower then 5.3