### PR TITLE
Convert deprecated string_... and array_.. functions 

### DIFF
--- a/src/Queue/Connectors/SqsFifoConnector.php
+++ b/src/Queue/Connectors/SqsFifoConnector.php
@@ -5,6 +5,8 @@ namespace ShiftOneLabs\LaravelSqsFifoQueue\Queue\Connectors;
 use Aws\Sqs\SqsClient;
 use InvalidArgumentException;
 use Illuminate\Queue\Connectors\SqsConnector;
+use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use ShiftOneLabs\LaravelSqsFifoQueue\SqsFifoQueue;
 
 class SqsFifoConnector extends SqsConnector
@@ -20,21 +22,21 @@ class SqsFifoConnector extends SqsConnector
     {
         $config = $this->getDefaultConfiguration($config);
 
-        if (!ends_with($config['queue'], '.fifo')) {
+        if (!Str::endsWith($config['queue'], '.fifo')) {
             throw new InvalidArgumentException('FIFO queue name must end in ".fifo"');
         }
 
         if (!empty($config['key']) && !empty($config['secret'])) {
-            $config['credentials'] = array_only($config, ['key', 'secret']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
         }
 
-        $group = array_pull($config, 'group', 'default');
-        $deduplicator = array_pull($config, 'deduplicator', 'unique');
+        $group = Arr::pull($config, 'group', 'default');
+        $deduplicator = Arr::pull($config, 'deduplicator', 'unique');
 
         return new SqsFifoQueue(
             new SqsClient($config),
             $config['queue'],
-            array_get($config, 'prefix', ''),
+            Arr::get($config, 'prefix', ''),
             $group,
             $deduplicator
         );

--- a/src/SqsFifoQueue.php
+++ b/src/SqsFifoQueue.php
@@ -7,6 +7,7 @@ use Aws\Sqs\SqsClient;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Illuminate\Queue\SqsQueue;
+use Illuminate\Support\Arr;
 use ShiftOneLabs\LaravelSqsFifoQueue\Contracts\Queue\Deduplicator;
 
 class SqsFifoQueue extends SqsQueue
@@ -248,6 +249,6 @@ class SqsFifoQueue extends SqsQueue
     {
         $payload = json_decode($payload, true);
 
-        return array_get($payload, $key, $default);
+        return Arr::get($payload, $key, $default);
     }
 }


### PR DESCRIPTION
Convert deprecated string_... and array_.. functions to the non-deprecated static helper variant, since these were removed in laravel 6.

Note that these changes appear to be covered by the existing tests. 