### PR TITLE
Lambda support by passing on 'token' from configuration to credentials

### DIFF
--- a/src/Queue/Connectors/SqsFifoConnector.php
+++ b/src/Queue/Connectors/SqsFifoConnector.php
@@ -27,7 +27,7 @@ class SqsFifoConnector extends SqsConnector
         }
 
         if (!empty($config['key']) && !empty($config['secret'])) {
-            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
         $group = Arr::pull($config, 'group', 'default');


### PR DESCRIPTION
Hi,

This simple fix, fixes an issue when running this SQS FIFO package on Lambda using something like https://github.com/brefphp/laravel-bridge

When working in Lambda you typically assign privileges to the Lambda function it-self. This means instead of receiving a access key id & secret the Lambda instance have temporary tokens that it pass on to the SDK for authentication. So passing on this token from the configuration side of things allows it to authenticate.

With this you'll be able to run server-less Lambda SQS FIFO handlers.