### PR TITLE
Run Travis CI on PHP 8.0, 8.1 and Laravel 9

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -33,6 +33,14 @@ build:
             environment:
                 php: 7.4
 
+        php80:
+          environment:
+            php: 8.0
+
+        php81:
+          environment:
+            php: 8.1
+
         analysis:
             environment:
                 php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 env:
   - ILLUMINATE_VERSION=4.1.*
@@ -27,6 +29,7 @@ env:
   - ILLUMINATE_VERSION=6.*
   - ILLUMINATE_VERSION=7.*
   - ILLUMINATE_VERSION=8.*
+  - ILLUMINATE_VERSION=9.*
 
 jobs:
   include:
@@ -60,6 +63,8 @@ jobs:
       env: ILLUMINATE_VERSION=7.*
     - php: 5.6
       env: ILLUMINATE_VERSION=8.*
+    - php: 5.6
+      env: ILLUMINATE_VERSION=9.*
     - php: 7.0
       env: ILLUMINATE_VERSION=5.6.*
     - php: 7.0
@@ -72,6 +77,8 @@ jobs:
       env: ILLUMINATE_VERSION=7.*
     - php: 7.0
       env: ILLUMINATE_VERSION=8.*
+    - php: 7.0
+      env: ILLUMINATE_VERSION=9.*
     - php: 7.1
       env: ILLUMINATE_VERSION=6.*
     - php: 7.1
@@ -80,6 +87,8 @@ jobs:
       env: ILLUMINATE_VERSION=8.*
     - php: 7.2
       env: ILLUMINATE_VERSION=8.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=9.*
 
 before_install:
   - composer self-update


### PR DESCRIPTION
Hey! This PR updates the `.travis.yml` config so that the tests can also be run on PHP 8.0 and 8.1. It also runs the tests against Laravel 9 :)