### PR TITLE
Soluction: must be compatible with Illuminate Str

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -44,7 +44,7 @@ class Str extends BaseStr
      *
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    public static function substr($string, $start, $length = null, $encoding = 'UTF-8')
     {
         return mb_substr($string, $start, $length, 'UTF-8');
     }


### PR DESCRIPTION
Declaration of ShiftOneLabs\\LaravelSqsFifoQueue\\Support\\Str::substr($string, $start, $length = null) must be compatible with Illuminate\\Support\\Str::substr($string, $start, $length = null, $encoding = 'UTF-8')