### PR TITLE
Update Str.php

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -44,8 +44,8 @@ class Str extends BaseStr
      *
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    public static function substr($string, $start, $length = null, $encoding = 'UTF-8')
     {
-        return mb_substr($string, $start, $length, 'UTF-8');
+        return mb_substr($string, $start, $length, $encoding);
     }
 }


### PR DESCRIPTION
fix Symfony\Component\ErrorHandler\Error\FatalError Declaration of ShiftOneLabs\LaravelSqsFifoQueue\Support\Str::substr($string, $start, $length = null) must be compatible with Illuminate\Support\Str::substr($string, $start, $length = null, $encoding = 'UTF-8')