### PR TITLE
Strip token from root config options on aws clients

### DIFF
--- a/src/Queue/Connectors/SqsFifoConnector.php
+++ b/src/Queue/Connectors/SqsFifoConnector.php
@@ -36,7 +36,9 @@ class SqsFifoConnector extends SqsConnector
         $allowDelay = (bool)Arr::pull($config, 'allow_delay', false);
 
         return new SqsFifoQueue(
-            new SqsClient($config),
+            new SqsClient(
+                Arr::except($config, ['token'])
+            ),
             $config['queue'],
             $config['prefix'] ?? '',
             $config['suffix'] ?? '',


### PR DESCRIPTION
Hi,

This fixes the error generated on sqs connection with aws client version >= 3.245.0.

References: https://github.com/laravel/framework/commit/acd4f4bb46f256a45dee74548539a148f52759dd