### PR TITLE
Add support for null queue

### DIFF
--- a/src/Queue/Connectors/SqsFifoConnector.php
+++ b/src/Queue/Connectors/SqsFifoConnector.php
@@ -22,7 +22,7 @@ class SqsFifoConnector extends SqsConnector
     {
         $config = $this->getDefaultConfiguration($config);
 
-        if (!Str::endsWith($config['queue'], '.fifo')) {
+        if (!empty($config['queue']) && !Str::endsWith($config['queue'], '.fifo')) {
             throw new InvalidArgumentException('FIFO queue name must end in ".fifo"');
         }
 


### PR DESCRIPTION
If the connection is configured without a queue, and the queue is provided while performing a pushRaw(), the operation will throw a warning:
```
DEPRECATED  str_ends_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
```

Additionally, the InvalidArgumentException blocks further execution even if a queue is provided to the push function.